### PR TITLE
Cope with change in RightAws

### DIFF
--- a/lib/capistrano/ec2group.rb
+++ b/lib/capistrano/ec2group.rb
@@ -20,7 +20,9 @@ module Capistrano
         @ec2_api ||= RightAws::Ec2.new(fetch(:aws_access_key_id), fetch(:aws_secret_access_key), fetch(:aws_params, {}))
 
         @ec2_api.describe_instances.delete_if{|i| i[:aws_state] != "running"}.each do |instance|
-          server(instance[:dns_name], *args) if instance[:aws_groups].include?(which.to_s)
+          instance[:groups].each do |group|
+            server(instance[:dns_name], *args) if group[:group_name].include?(which.to_s)
+          end
         end
       end
     end


### PR DESCRIPTION
This change to right_aws https://github.com/rightscale/right_aws/commit/8fa4bd0163214e8d245c35dc1d76927809d67e5b#diff-5 changes the way groups are handled.

This patch fixes it.
