### PR TITLE
Fix to instance group comparison

### DIFF
--- a/lib/capistrano/ec2group.rb
+++ b/lib/capistrano/ec2group.rb
@@ -21,7 +21,7 @@ module Capistrano
 
         @ec2_api.describe_instances.delete_if{|i| i[:aws_state] != "running"}.each do |instance|
           instance[:groups].each do |group|
-            server(fetch(:aws_pvt_dns) ? instance[:private_dns_name] : instance[:dns_name], *args) if group[:group_name].include?(which.to_s)
+            server(fetch(:aws_pvt_dns) ? instance[:private_dns_name] : instance[:dns_name], *args) if group[:group_name] == which.to_s
           end
         end
       end


### PR DESCRIPTION
Fixed comparison made between value specified by group capistrano
directive and each instance group. Former implementation used
String#include? to compare, which doesn't match only the intended
group.

Commit e08ac1f1565bdfb3e61257012e1eff8e38626da9 broke the original intended behavior. This fixes it.

Thanks!
